### PR TITLE
Early exits while finding spendable outputs

### DIFF
--- a/utxo_set.go
+++ b/utxo_set.go
@@ -28,6 +28,10 @@ func (u UTXOSet) FindSpendableOutputs(pubkeyHash []byte, amount int) (int, map[s
 			txID := hex.EncodeToString(k)
 			outs := DeserializeOutputs(v)
 
+			if accumulated >= amount {
+				break
+			}
+
 			for outIdx, out := range outs.Outputs {
 				if out.IsLockedWithKey(pubkeyHash) && accumulated < amount {
 					accumulated += out.Value


### PR DESCRIPTION
When `accumulated >= amount` satisfied, the below logic is not needed, so we can early exit in here.