### PR TITLE
Adding a Basic Check to prevent users sending txn's to themselves

### DIFF
--- a/cli_send.go
+++ b/cli_send.go
@@ -12,6 +12,11 @@ func (cli *CLI) send(from, to string, amount int, nodeID string, mineNow bool) {
 	if !ValidateAddress(to) {
 		log.Panic("ERROR: Recipient address is not valid")
 	}
+	if to == from {
+		log.Panic("ERROR: You cannot send coins to yourself")
+	} else if from == to {
+		log.Panic("ERROR: You cannot send coins to yourself")
+	}
 
 	bc := NewBlockchain(nodeID)
 	UTXOSet := UTXOSet{bc}


### PR DESCRIPTION
This is Super basic check to prevent Mine Padding i could not replicate the account balance doubling reported in #36 

Before Self Send TXN:
```
NODE_ID=3000 ./blockchain_go getbalance -address 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw

Balance of '1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw': 19
```

Create the TXN and Mine it:
```
NODE_ID=3000 ./blockchain_go send -to 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw -from 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw -amount 19 -mine

70fdd3b38c2ad069752ef0621eeb3f94fd1b4d01ec31768f921e78c79be1841f

Success!
```

After the TXN:
```
NODE_ID=3000 ./blockchain_go getbalance -address 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw

Balance of '1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw': 29
```

After the Change:
```
NODE_ID=3000 ./blockchain_go send -to 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw -from 1CLQCfLafpQqGuye9fRLhrmZg8HzqZtJZw -amount 19 -mine

2018/07/25 18:11:29 ERROR: You cannot send coins to yourself
panic: ERROR: You cannot send coins to yourself

goroutine 1 [running]:
log.Panic(0xc420077d20, 0x1, 0x1)
        /usr/lib/golang/src/log/log.go:326 +0xc0
github.com/setkeh/blockchain_go/cli.(*CLI).send(0xc420077f78, 0x7ffecd3ee139, 0x22, 0x7ffecd3ee110, 0x22, 0x13, 0xc42001a0e8, 0x4, 0x1)
        /home/setkeh/gocode/src/github.com/setkeh/blockchain_go/cli/cli_send.go:19 +0x4f8
github.com/setkeh/blockchain_go/cli.(*CLI).Run(0xc420077f78)
        /home/setkeh/gocode/src/github.com/setkeh/blockchain_go/cli/cli.go:144 +0x6db
main.main()
        /home/setkeh/gocode/src/github.com/setkeh/blockchain_go/main.go:7 +0x2b

```

The Balance only Increases by the subsidy `const subsidy = 10` this is still a problem though as it allows users to just mine the subsidy on a *Fake* transaction.

I am also investigating a better way of dealing with this by invalidating the block or something along those lines to make the network deal with the issue instead of a client.