### PR TITLE
used UTXO_set index directly  to set TxInput.Vout  was a bug. 

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -178,6 +178,7 @@ func (bc *Blockchain) FindUTXO() map[string]TXOutputs {
 
 				outs := UTXO[txID]
 				outs.Outputs = append(outs.Outputs, out)
+				outs.OutIdxs = append(outs.OutIdxs,outIdx)
 				UTXO[txID] = outs
 			}
 

--- a/transaction_output.go
+++ b/transaction_output.go
@@ -35,6 +35,7 @@ func NewTXOutput(value int, address string) *TXOutput {
 // TXOutputs collects TXOutput
 type TXOutputs struct {
 	Outputs []TXOutput
+	OutIdxs []int
 }
 
 // Serialize serializes TXOutputs

--- a/utxo_set.go
+++ b/utxo_set.go
@@ -31,7 +31,7 @@ func (u UTXOSet) FindSpendableOutputs(pubkeyHash []byte, amount int) (int, map[s
 			for outIdx, out := range outs.Outputs {
 				if out.IsLockedWithKey(pubkeyHash) && accumulated < amount {
 					accumulated += out.Value
-					unspentOutputs[txID] = append(unspentOutputs[txID], outIdx)
+					unspentOutputs[txID] = append(unspentOutputs[txID], outs.OutIdxs[outIdx])
 				}
 			}
 		}
@@ -153,9 +153,16 @@ func (u UTXOSet) Update(block *Block) {
 					outsBytes := b.Get(vin.Txid)
 					outs := DeserializeOutputs(outsBytes)
 
-					for outIdx, out := range outs.Outputs {
+					//for outIdx, out := range outs.Outputs {
+					//	if outIdx != vin.Vout {
+					//		updatedOuts.Outputs = append(updatedOuts.Outputs, out)
+					//	}
+					//}
+
+					for idx, outIdx := range outs.OutIdxs {
 						if outIdx != vin.Vout {
-							updatedOuts.Outputs = append(updatedOuts.Outputs, out)
+							updatedOuts.Outputs = append(updatedOuts.Outputs, outs.Outputs[idx])
+							updatedOuts.OutIdxs = append(updatedOuts.OutIdxs, outIdx)
 						}
 					}
 
@@ -175,8 +182,9 @@ func (u UTXOSet) Update(block *Block) {
 			}
 
 			newOutputs := TXOutputs{}
-			for _, out := range tx.Vout {
+			for idx, out := range tx.Vout {
 				newOutputs.Outputs = append(newOutputs.Outputs, out)
+				newOutputs.OutIdxs = append(newOutputs.OutIdxs, idx)
 			}
 
 			err := b.Put(tx.ID, newOutputs.Serialize())


### PR DESCRIPTION
```

acc, validOutputs := UTXOSet.FindSpendableOutputs(pubKeyHash, amount)

	if acc < amount {
		log.Panic("ERROR: Not enough funds")
	}

	// Build a list of inputs
	for txid, outs := range validOutputs {
		txID, err := hex.DecodeString(txid)
		if err != nil {
			log.Panic(err)
		}

		for _, out := range outs {
			input := TXInput{txID, out, nil, wallet.PublicKey}
			inputs = append(inputs, input)
		}
	}

```
used UTXO_set index directly  to set TxInput.Vout  was a bug. 
because exist TxOutput has been used,  the TxOutput index is different from UTXO_set index
 