### PR TITLE
Rename utility function IntToHex to IntToBytes

### DIFF
--- a/proofofwork.go
+++ b/proofofwork.go
@@ -35,9 +35,9 @@ func (pow *ProofOfWork) prepareData(nonce int) []byte {
 		[][]byte{
 			pow.block.PrevBlockHash,
 			pow.block.HashTransactions(),
-			IntToHex(pow.block.Timestamp),
-			IntToHex(int64(targetBits)),
-			IntToHex(int64(nonce)),
+			IntToBytes(pow.block.Timestamp),
+			IntToBytes(int64(targetBits)),
+			IntToBytes(int64(nonce)),
 		},
 		[]byte{},
 	)

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 // IntToHex converts an int64 to a byte array
-func IntToHex(num int64) []byte {
+func IntToBytes(num int64) []byte {
 	buff := new(bytes.Buffer)
 	err := binary.Write(buff, binary.BigEndian, num)
 	if err != nil {


### PR DESCRIPTION
Rename utility function IntToHex to IntToBytes because function convert Int64 into []byte. 
Often I see comments of people who read that tutorial that they are confused because of IntToHex function.