### PR TITLE
bugFix: initialize nodeaddess to avoid empty value in send coin scenario.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -39,6 +39,7 @@ func (cli *CLI) Run() {
 		fmt.Printf("NODE_ID env. var is not set!")
 		os.Exit(1)
 	}
+	nodeAddress = fmt.Sprintf("localhost:%s", nodeID)
 
 	getBalanceCmd := flag.NewFlagSet("getbalance", flag.ExitOnError)
 	createBlockchainCmd := flag.NewFlagSet("createblockchain", flag.ExitOnError)

--- a/server.go
+++ b/server.go
@@ -318,7 +318,7 @@ func handleTx(request []byte, bc *Blockchain) {
 			}
 		}
 	} else {
-		if len(mempool) >= 2 && len(miningAddress) > 0 {
+		if len(mempool) >= 1 && len(miningAddress) > 0 {
 		MineTransactions:
 			var txs []*Transaction
 


### PR DESCRIPTION
fix nodeaddess empty value when send coins.