### PR TITLE
fix: `gob: type elliptic.p256Curve has no exported fields. `

### DIFF
--- a/wallets.go
+++ b/wallets.go
@@ -2,19 +2,27 @@ package main
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"encoding/gob"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/big"
 	"os"
 )
 
 const walletFile = "wallet_%s.dat"
 
-// Wallets stores a collection of wallets
 type Wallets struct {
 	Wallets map[string]*Wallet
+}
+
+// SerializableWallet Solve gob: type elliptic.p256Curve has no exported fields
+type SerializableWallet struct {
+	D         *big.Int
+	X, Y      *big.Int
+	PublicKey []byte
 }
 
 // NewWallets creates Wallets and fills it from a file if it exists
@@ -55,7 +63,9 @@ func (ws Wallets) GetWallet(address string) Wallet {
 
 // LoadFromFile loads wallets from the file
 func (ws *Wallets) LoadFromFile(nodeID string) error {
+
 	walletFile := fmt.Sprintf(walletFile, nodeID)
+	//fmt.Println(walletFile)
 	if _, err := os.Stat(walletFile); os.IsNotExist(err) {
 		return err
 	}
@@ -65,15 +75,29 @@ func (ws *Wallets) LoadFromFile(nodeID string) error {
 		log.Panic(err)
 	}
 
-	var wallets Wallets
-	gob.Register(elliptic.P256())
+	var wallets map[string]SerializableWallet
+	//gob.Register(elliptic.P256())
+	gob.Register(SerializableWallet{})
 	decoder := gob.NewDecoder(bytes.NewReader(fileContent))
 	err = decoder.Decode(&wallets)
 	if err != nil {
 		log.Panic(err)
 	}
-
-	ws.Wallets = wallets.Wallets
+	ws.Wallets = make(map[string]*Wallet)
+	//ws.Wallets = wallets.Wallets
+	for k, v := range wallets {
+		ws.Wallets[k] = &Wallet{
+			PrivateKey: ecdsa.PrivateKey{
+				PublicKey: ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     v.X,
+					Y:     v.Y,
+				},
+				D: v.D,
+			},
+			PublicKey: v.PublicKey,
+		}
+	}
 
 	return nil
 }
@@ -82,17 +106,29 @@ func (ws *Wallets) LoadFromFile(nodeID string) error {
 func (ws Wallets) SaveToFile(nodeID string) {
 	var content bytes.Buffer
 	walletFile := fmt.Sprintf(walletFile, nodeID)
+	//fmt.Println(walletFile)
 
-	gob.Register(elliptic.P256())
+	gob.Register(SerializableWallet{})
+
+	wallets := make(map[string]SerializableWallet)
+	for k, v := range ws.Wallets {
+		wallets[k] = SerializableWallet{
+			D:         v.PrivateKey.D,
+			X:         v.PrivateKey.PublicKey.X,
+			Y:         v.PrivateKey.PublicKey.Y,
+			PublicKey: v.PublicKey,
+		}
+	}
 
 	encoder := gob.NewEncoder(&content)
-	err := encoder.Encode(ws)
+	err := encoder.Encode(wallets)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	err = ioutil.WriteFile(walletFile, content.Bytes(), 0644)
+	err = os.WriteFile(walletFile, content.Bytes(), 0644)
 	if err != nil {
 		log.Panic(err)
 	}
+
 }


### PR DESCRIPTION
When I read the wallet file using the code in the original code, I encountered this error: 
`gob: type elliptic.p256Curve has no exported fields. ` 
This is due to the fact that the `elliptic.p256Curve` type in the `crypto/elliptic` package has no exported fields, whereas the Gob encoder requires that all fields in the struct must be exported. 
So I defined an exportable type, `SerializableWallet`, to store the parameters of the elliptic curve, and modified the decoding and encoding parts of the `LoadFromFile` and `SaveToFile` methods.